### PR TITLE
Fixed cloudformation script timing out

### DIFF
--- a/mlu_computer_vision.yaml
+++ b/mlu_computer_vision.yaml
@@ -19,7 +19,6 @@ Metadata:
           default: "Notebook Lifecycle Configuration"
         Parameters: 
           - NotebookLifecycleName
-          - NotebookLifecycleOnCreate
           - NotebookLifecycleOnStart
 
 Parameters:
@@ -52,41 +51,6 @@ Parameters:
     Default: tfc-training-lifecycle
     Description: Notebook lifecycle name. Default is tfc-training-lifecycle
 
-  NotebookLifecycleOnCreate:
-    Type: String
-    Default: |
-      #!/bin/bash
-
-      set -e
-
-      # Install required library
-      sudo -u ec2-user -i <<'EOF'
-      # PARAMETERS
-      PACKAGE=scikit-image
-      ENVIRONMENT=mxnet_p36
-
-      source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
-      pip install --upgrade "$PACKAGE"
-      source /home/ec2-user/anaconda3/bin/deactivate
-
-      # PARAMETERS - install scikit-image on python3 environment
-      ENVIRONMENT=python3
-
-      source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
-      pip install --upgrade "$PACKAGE"
-      source /home/ec2-user/anaconda3/bin/deactivate
-
-      # Download dataset
-      BASEURL="https://d8mrh1kj01ho9.cloudfront.net/workshop/cv1/data/"
-      FILES='example_dataset.pkl training_data.pkl test_data.pkl sample_model_output.csv'
-
-      for file in $FILES; do
-          cd /tmp && { curl -O "$BASEURL$file" ; cd -; }
-      done
-
-      EOF
-    Description: Notebook lifecycle name. Default is tfc-training-lifecycle
-
   NotebookLifecycleOnStart:
     Type: String
     Default: |
@@ -101,14 +65,14 @@ Parameters:
       ENVIRONMENT=mxnet_p36
 
       source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
-      pip install --upgrade "$PACKAGE"
+      nohup pip install --upgrade pip "$PACKAGE" &
       source /home/ec2-user/anaconda3/bin/deactivate
 
       # PARAMETERS - install scikit-image on python3 environment
       ENVIRONMENT=python3
 
       source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
-      pip install --upgrade "$PACKAGE"
+      nohup pip install --upgrade pip "$PACKAGE" &
       source /home/ec2-user/anaconda3/bin/deactivate
 
       # Download dataset (if removed from tmp folder)
@@ -168,9 +132,6 @@ Resources:
     Type: "AWS::SageMaker::NotebookInstanceLifecycleConfig"
     Properties: 
       NotebookInstanceLifecycleConfigName: !Ref NotebookLifecycleName
-      OnCreate: 
-        - Content:
-            Fn::Base64: !Ref NotebookLifecycleOnCreate
       OnStart: 
         - Content:
             Fn::Base64: !Ref NotebookLifecycleOnStart


### PR DESCRIPTION
2 issues were found

1. Fix cloudformation script timing out as the pip installation was talking too long. Made the installation run as a background task within shell.
2. The existing pip version was failing to install the new scikit-image library due to an update to one of the dependencies. Updated the pip installer prior to installing scikit-image.