### PR TITLE
Fix lifecycle script to install pip before install scikit-image.

### DIFF
--- a/mlu_computer_vision.yaml
+++ b/mlu_computer_vision.yaml
@@ -65,13 +65,7 @@ Parameters:
       ENVIRONMENT=mxnet_p36
 
       source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
-      nohup pip install --upgrade pip "$PACKAGE" &
-      source /home/ec2-user/anaconda3/bin/deactivate
-
-      # PARAMETERS - install scikit-image on python3 environment
-      ENVIRONMENT=python3
-
-      source /home/ec2-user/anaconda3/bin/activate "$ENVIRONMENT"
+      pip install --upgrade pip
       nohup pip install --upgrade pip "$PACKAGE" &
       source /home/ec2-user/anaconda3/bin/deactivate
 


### PR DESCRIPTION
Fixed lifecycle script to upgrade pip first before installing scikit-image. 

Note: A compromised was made to remove the installation of scikit-image into the python conda env as well as this will cause CF script to timeout. The lifecycle script will only install scikit-image into the mxnet_p36 kernet.